### PR TITLE
fix Axios MaxBodyLengthExceededError

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -35,7 +35,11 @@ const deploy = async (url, authContext, filePath) => {
 
   data.append("file", file, base);
 
-  const config = { headers: { ...data.getHeaders(), ...authContext.headers } };
+  const config = {
+    maxContentLength: Infinity,
+    maxBodyLength: Infinity,
+    headers: { ...data.getHeaders(), ...authContext.headers }
+  };
 
   return axios.post(url, data, config).then(({ data: { id = "" } }) => {
     if (!id) {


### PR DESCRIPTION
Hi @leo-ls,
I've come across the issue of not being able to upload certain MTAR files.

I believe the default maxBodyLength for Axios is 10MB and my current project has 70MB that's why i was getting a MaxBodyLengthExceededError and could not deploy.

My changes should fix this issue.



